### PR TITLE
[feature] Named streams

### DIFF
--- a/event_sourcery/exceptions.py
+++ b/event_sourcery/exceptions.py
@@ -12,3 +12,11 @@ class ConcurrentStreamWriteError(EventStoreException):
 
 class Misconfiguration(EventStoreException):
     pass
+
+
+class AnotherStreamWithThisNameButOtherIdExists(EventStoreException):
+    pass
+
+
+class EitherStreamIdOrStreamNameIsRequired(EventStoreException):
+    pass

--- a/event_sourcery/interfaces/storage_strategy.py
+++ b/event_sourcery/interfaces/storage_strategy.py
@@ -8,7 +8,11 @@ from event_sourcery.types.stream_id import StreamId
 class StorageStrategy(abc.ABC):
     @abc.abstractmethod
     def fetch_events(
-        self, stream_id: StreamId, start: int | None = None, stop: int | None = None
+        self,
+        stream_id: StreamId | None,
+        stream_name: str | None,
+        start: int | None = None,
+        stop: int | None = None,
     ) -> list[RawEventDict]:
         pass
 
@@ -25,7 +29,9 @@ class StorageStrategy(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def ensure_stream(self, stream_id: StreamId, expected_version: int) -> None:
+    def ensure_stream(
+        self, stream_id: StreamId | None, stream_name: str | None, expected_version: int
+    ) -> StreamId:
         pass
 
     @abc.abstractmethod

--- a/event_sourcery_sqlalchemy/models.py
+++ b/event_sourcery_sqlalchemy/models.py
@@ -16,7 +16,7 @@ class Stream:
     __tablename__ = "event_sourcery_streams"
 
     uuid = Column(GUID(), primary_key=True)
-    name = Column(String(40), unique=True, nullable=True)
+    name = Column(String(255), unique=True, nullable=True)
     version = Column(BigInteger(), nullable=False)
 
 

--- a/event_sourcery_sqlalchemy/models.py
+++ b/event_sourcery_sqlalchemy/models.py
@@ -16,6 +16,7 @@ class Stream:
     __tablename__ = "event_sourcery_streams"
 
     uuid = Column(GUID(), primary_key=True)
+    name = Column(String(40), unique=True, nullable=True)
     version = Column(BigInteger(), nullable=False)
 
 

--- a/event_sourcery_sqlalchemy/sqlalchemy_event_store.py
+++ b/event_sourcery_sqlalchemy/sqlalchemy_event_store.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Callable, Iterator, Union
+from uuid import uuid4
 
 from sqlalchemy import delete
 from sqlalchemy import event as sa_event
@@ -9,7 +10,10 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
 
 from event_sourcery.dto.raw_event_dict import RawEventDict
-from event_sourcery.exceptions import ConcurrentStreamWriteError
+from event_sourcery.exceptions import (
+    AnotherStreamWithThisNameButOtherIdExists,
+    ConcurrentStreamWriteError,
+)
 from event_sourcery.interfaces.storage_strategy import StorageStrategy
 from event_sourcery.types.stream_id import StreamId
 from event_sourcery_sqlalchemy.models import Event as EventModel
@@ -45,13 +49,22 @@ class SqlAlchemyStorageStrategy(StorageStrategy):
                 )
 
     def fetch_events(
-        self, stream_id: StreamId, start: int | None = None, stop: int | None = None
+        self,
+        stream_id: StreamId | None,
+        stream_name: str | None,
+        start: int | None = None,
+        stop: int | None = None,
     ) -> list[RawEventDict]:
-        events_stmt = (
-            select(EventModel)
-            .filter(EventModel.stream_id == stream_id)
-            .order_by(EventModel.version)
-        )
+        events_stmt = select(EventModel).order_by(EventModel.version)
+        if stream_id is not None:
+            events_stmt = events_stmt.filter(EventModel.stream_id == stream_id)
+        if stream_name is not None:
+            stream_id_subq = (
+                select(StreamModel.uuid)
+                .filter(StreamModel.name == stream_name)
+                .subquery()
+            )
+            events_stmt = events_stmt.filter(EventModel.stream_id == stream_id_subq)
         if start is not None:
             events_stmt = events_stmt.filter(EventModel.version >= start)
 
@@ -100,16 +113,30 @@ class SqlAlchemyStorageStrategy(StorageStrategy):
         ]
         return raw_dict_events
 
-    def ensure_stream(self, stream_id: StreamId, expected_version: int) -> None:
+    def ensure_stream(
+        self, stream_id: StreamId | None, stream_name: str | None, expected_version: int
+    ) -> StreamId:
+        given_stream_id = stream_id
+        if stream_id is None:
+            stream_id = uuid4()
+
         ensure_stream_stmt = (
             postgresql_insert(StreamModel)
             .values(
                 uuid=stream_id,
+                name=stream_name,
                 version=1,
             )
             .on_conflict_do_nothing()
         )
         self._session.execute(ensure_stream_stmt)
+        if stream_name is not None:
+            get_stream_id_stmt = select(StreamModel.uuid).filter(
+                StreamModel.name == stream_name
+            )
+            stream_id = self._session.execute(get_stream_id_stmt).scalar()
+            if given_stream_id is not None and stream_id != given_stream_id:
+                raise AnotherStreamWithThisNameButOtherIdExists()
 
         if expected_version:
             stmt = (
@@ -118,12 +145,17 @@ class SqlAlchemyStorageStrategy(StorageStrategy):
                     StreamModel.uuid == stream_id,
                     StreamModel.version == expected_version,
                 )
-                .values(version=StreamModel.version + 1)
+                .values(
+                    version=StreamModel.version + 1
+                )  # TODO: may not be true! for inserting multiple events at once
             )
             result = self._session.execute(stmt)
 
             if result.rowcount != 1:  # optimistic lock failed
                 raise ConcurrentStreamWriteError
+
+        assert stream_id is not None
+        return stream_id
 
     def insert_events(self, events: list[RawEventDict]) -> None:
         rows = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,6 @@ def engine(request: SubRequest, declarative_base: DeclarativeBase) -> Iterator[E
     try:
         declarative_base.metadata.create_all(bind=engine)
     except OperationalError:
-        raise
         pytest.skip(f"{engine.url.drivername} test database not available, skipping")
     else:
         yield engine

--- a/tests/event_store/test_named_streams.py
+++ b/tests/event_store/test_named_streams.py
@@ -1,0 +1,93 @@
+from uuid import uuid4
+
+import pytest
+
+from event_sourcery.event_store import EventStore
+from event_sourcery.exceptions import (
+    AnotherStreamWithThisNameButOtherIdExists,
+    EitherStreamIdOrStreamNameIsRequired,
+)
+from tests.events import SomeEvent
+
+
+def test_can_append_then_load_with_named_stream(event_store: EventStore) -> None:
+    an_event = SomeEvent(first_name="Dziabong")
+    event_store.append(stream_name="Test #1", events=[an_event])
+
+    events = event_store.load_stream(stream_name="Test #1")
+
+    assert events == [an_event.copy(update={"version": 1})]
+
+
+@pytest.mark.skip("Hard to say how .iter api should change")
+def test_can_iter_over_named_stream(event_store: EventStore) -> None:
+    an_event = SomeEvent(first_name="Ciapong")
+    event_store.append(stream_name="Test #2", events=[an_event])
+
+    list(event_store.iter())
+
+
+def test_can_append_then_load_with_named_stream_with_assigned_uuid(
+    event_store: EventStore,
+) -> None:
+    an_event = SomeEvent(first_name="Brzdeng")
+    stream_id = uuid4()
+    event_store.append(stream_id=stream_id, stream_name="Test #3", events=[an_event])
+
+    events_by_stream_id = event_store.load_stream(stream_id=stream_id)
+    events_by_stream_name = event_store.load_stream(stream_name="Test #3")
+
+    assert (
+        events_by_stream_id
+        == events_by_stream_name
+        == [an_event.copy(update={"version": 1})]
+    )
+
+
+def test_lets_appending_by_both_id_and_name_then_just_name(
+    event_store: EventStore,
+) -> None:
+    an_event = SomeEvent(first_name="Cing")
+    stream_id = uuid4()
+    event_store.append(stream_id=stream_id, stream_name="Test #4", events=[an_event])
+    another_event = SomeEvent(first_name="Ciang")
+    event_store.append(
+        stream_name="Test #4", events=[another_event], expected_version=1
+    )
+
+    events_by_stream_id = event_store.load_stream(stream_id=stream_id)
+    events_by_stream_name = event_store.load_stream(stream_name="Test #4")
+
+    assert (
+        events_by_stream_id
+        == events_by_stream_name
+        == [
+            an_event.copy(update={"version": 1}),
+            another_event.copy(update={"version": 2}),
+        ]
+    )
+
+
+def test_does_not_allow_to_steal_name_for_other_stream_id(
+    event_store: EventStore,
+) -> None:
+    an_event = SomeEvent(first_name="Ciong")
+    stream_id = uuid4()
+    event_store.append(stream_id=stream_id, stream_name="Test #5", events=[an_event])
+    another_event = SomeEvent(first_name="Ciong 2")
+    another_stream_id = uuid4()
+
+    with pytest.raises(AnotherStreamWithThisNameButOtherIdExists):
+        event_store.append(
+            stream_id=another_stream_id,
+            stream_name="Test #5",
+            events=[another_event],
+            expected_version=1,
+        )
+
+
+def test_raises_exception_if_name_nor_id_given(event_store: EventStore) -> None:
+    an_event = SomeEvent(first_name="Ciang 2")
+
+    with pytest.raises(EitherStreamIdOrStreamNameIsRequired):
+        event_store.append(events=[an_event])


### PR DESCRIPTION
- uses another field in stream table to store stream name
- if stream_id is not given, it will be generated - but it's not visible to the client
- if a client tries to assign stream_id to a named stream that already has one, it will result in exception