### PR TITLE
Limit number of queries in appending events

### DIFF
--- a/event_sourcery/event_store/event_store.py
+++ b/event_sourcery/event_store/event_store.py
@@ -127,12 +127,10 @@ class EventStore:
         else:
             versioning = NO_VERSIONING
 
-        self._storage_strategy.ensure_stream(
-            stream_id=stream_id,
-            versioning=versioning,
-        )
         serialized_events = self._serialize_events(events, stream_id)
-        self._storage_strategy.insert_events(serialized_events)
+        self._storage_strategy.insert_events(
+            stream_id=stream_id, versioning=versioning, events=serialized_events
+        )
         return serialized_events
 
     def delete_stream(self, stream_id: StreamId) -> None:

--- a/event_sourcery/event_store/in_memory.py
+++ b/event_sourcery/event_store/in_memory.py
@@ -116,13 +116,16 @@ class InMemoryStorageStrategy(StorageStrategy):
         )
         return list(stream)
 
-    def insert_events(self, events: list[RawEvent]) -> None:
+    def insert_events(
+        self, stream_id: StreamId, versioning: Versioning, events: list[RawEvent]
+    ) -> None:
+        self._ensure_stream(stream_id=stream_id, versioning=versioning)
         self._storage.append(events)
 
     def save_snapshot(self, snapshot: RawEvent) -> None:
         self._storage.replace(with_snapshot=snapshot)
 
-    def ensure_stream(self, stream_id: StreamId, versioning: Versioning) -> None:
+    def _ensure_stream(self, stream_id: StreamId, versioning: Versioning) -> None:
         if stream_id not in self._storage:
             self._storage.create(stream_id, versioning)
 

--- a/event_sourcery/event_store/interfaces.py
+++ b/event_sourcery/event_store/interfaces.py
@@ -32,15 +32,13 @@ class StorageStrategy(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def insert_events(self, events: list[RawEvent]) -> None:
+    def insert_events(
+        self, stream_id: StreamId, versioning: Versioning, events: list[RawEvent]
+    ) -> None:
         pass
 
     @abc.abstractmethod
     def save_snapshot(self, snapshot: RawEvent) -> None:
-        pass
-
-    @abc.abstractmethod
-    def ensure_stream(self, stream_id: StreamId, versioning: Versioning) -> None:
         pass
 
     @abc.abstractmethod

--- a/event_sourcery_esdb/event_store.py
+++ b/event_sourcery_esdb/event_store.py
@@ -59,7 +59,10 @@ class ESDBStorageStrategy(StorageStrategy):
         except NotFound:
             return None
 
-    def insert_events(self, events: list[RawEvent]) -> None:
+    def insert_events(
+        self, stream_id: StreamId, versioning: Versioning, events: list[RawEvent]
+    ) -> None:
+        self._ensure_stream(stream_id=stream_id, versioning=versioning)
         for stream_id in {e.stream_id for e in events}:
             stream_name = stream.Name(stream_id)
             stream_events = [e for e in events if e.stream_id == stream_id]
@@ -82,7 +85,7 @@ class ESDBStorageStrategy(StorageStrategy):
             events=[dto.new_entry(snapshot, stream_position=stream_position)],
         )
 
-    def ensure_stream(self, stream_id: StreamId, versioning: Versioning) -> None:
+    def _ensure_stream(self, stream_id: StreamId, versioning: Versioning) -> None:
         name = stream.Name(stream_id)
 
         if versioning is not NO_VERSIONING and versioning.expected_version:

--- a/event_sourcery_sqlalchemy/models.py
+++ b/event_sourcery_sqlalchemy/models.py
@@ -61,10 +61,6 @@ class Stream:
         UniqueConstraint("name", "category"),
     )
 
-    def __init__(self, stream_id: StreamId, version: int | None) -> None:
-        self.stream_id = stream_id
-        self.version = version
-
     id = mapped_column(BigInteger().with_variant(Integer(), "sqlite"), primary_key=True)
     uuid = mapped_column(GUID(), nullable=False)
     name = mapped_column(String(255), nullable=True, default=None)
@@ -77,12 +73,6 @@ class Stream:
     @hybrid_property
     def stream_id(self) -> StreamId:
         return StreamId(self.uuid, self.name, category=self.category or None)
-
-    @stream_id.inplace.setter
-    def _stream_id_setter(self, value: StreamId) -> None:
-        self.uuid = value
-        self.name = value.name
-        self.category = value.category or ""
 
     @stream_id.inplace.comparator
     @classmethod

--- a/poetry.lock
+++ b/poetry.lock
@@ -836,6 +836,17 @@ files = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.2.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "more-itertools-10.2.0.tar.gz", hash = "sha256:8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1"},
+    {file = "more_itertools-10.2.0-py3-none-any.whl", hash = "sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684"},
+]
+
+[[package]]
 name = "mypy"
 version = "1.0.1"
 description = "Optional static typing for Python"
@@ -1591,4 +1602,4 @@ kombu = ["kombu"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "3e0483f9831f9ea35fb828081ea89cb6b1c696deade7c0b1c901460b0825527e"
+content-hash = "d90835f6d164243cf6413e5b66fd4c661f6f239a19a97cb6e87e4288e4b028fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ SQLAlchemy = ">=2.0"
 esdbclient = ">=1.0b3"
 kombu = {version = "*", optional = true}
 cloudevents = {version = "*", optional = true}
+more-itertools = "*"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/tests/event_store/test_save_retrieval.py
+++ b/tests/event_store/test_save_retrieval.py
@@ -13,6 +13,13 @@ def test_save_retrieve(given: Given, when: When, then: Then) -> None:
     then.stream(stream_id).loads_only([event])
 
 
+def test_save_retrieve_multiple_times(given: Given, when: When, then: Then) -> None:
+    given.stream(stream_id := StreamId())
+    when.appends(event_1 := an_event(), event_2 := an_event(), to=stream_id)
+    when.appends(event_3 := an_event(), to=stream_id)
+    then.stream(stream_id).loads_only([event_1, event_2, event_3])
+
+
 def test_save_retrieve_part_of_stream(given: Given, then: Then) -> None:
     given.stream(stream_id := StreamId())
     given.events(


### PR DESCRIPTION
- Made `ensure_stream` private and no longer part of `StorageStrategy` abstract class
- Rewrote `_ensure_stream` in SQLAlchemy backend to use less queries and cache `Stream` at the level of session, so we can use it in appending events and no longer query `Stream` for each event

@lzukowski see if we can make any alterations to EventStoreDB backend. Especially you felt `ensure_stream` is awkward there as well